### PR TITLE
Support for PostgreSQL compatible databases (trim version)

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -106,7 +106,7 @@ func (c *Collector) snapshot() {
 	defer c.lock.Unlock()
 
 	var version string
-	err := c.db.QueryRow(`SELECT setting FROM pg_settings WHERE name='server_version'`).Scan(&version)
+	err := c.db.QueryRow(`SELECT regexp_replace(setting,'[^0-9.].*','') setting FROM pg_settings WHERE name='server_version'`).Scan(&version)
 	if err != nil {
 		c.logger.Warning(err)
 		return


### PR DESCRIPTION
This is to support PostgreSQL compatible databases which shows additional info in the version number
Example with YugabyteDB (PostgreSQL-compatible open source distributed SQL database) 
```
yugabyte=# SELECT setting FROM pg_settings WHERE name='server_version';

       setting
---------------------
 11.2-YB-2.15.0.1-b0
```
This just trims additional characters so that only `11.2` is retained