### PR TITLE
Replication metrics

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -32,6 +32,11 @@ var (
 	dTopQueryIOTime = desc("pg_top_query_io_time_per_second", "Time the query spent awaiting IO", "db", "user", "query")
 
 	dLockAwaitingQueries = desc("pg_lock_awaiting_queries", "Number of queries awaiting a lock", "db", "user", "blocking_query")
+
+	dWalReceiverStatus = desc("pg_wal_receiver_status", "WAL receiver status: 1 if the receiver is connected, otherwise 0", "sender")
+	dWalCurrentLsn     = desc("pg_wal_current_lsn", "Current WAL sequence number")
+	dWalReceiveLsn     = desc("pg_wal_receive_lsn", "WAL sequence number that has been received and synced to disk by streaming replication")
+	dWalReplyLsn       = desc("pg_wal_reply_lsn", "WAL sequence number that has been replayed during recovery")
 )
 
 type QueryKey struct {
@@ -68,6 +73,7 @@ type Collector struct {
 	saCurr            *saSnapshot
 	saPrev            *saSnapshot
 	settings          []Setting
+	replicationStatus ReplicationStatus
 
 	lock   sync.RWMutex
 	logger logger.Logger
@@ -131,6 +137,9 @@ func (c *Collector) snapshot() {
 		return
 	}
 	if c.settings, err = c.getSettings(); err != nil {
+		c.logger.Warning(err)
+	}
+	if c.replicationStatus, err = c.getReplicationStatus(version); err != nil {
 		c.logger.Warning(err)
 	}
 }
@@ -270,6 +279,32 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	for _, s := range c.settings {
 		ch <- gauge(dSettings, s.Value, s.Name, s.Unit)
 	}
+	rs := c.replicationStatus
+	if rs.CurrentLsn.Valid {
+		ch <- counter(dWalCurrentLsn, float64(rs.CurrentLsn.Int64))
+	}
+	if rs.ReceiveLsn.Valid {
+		ch <- counter(dWalReceiveLsn, float64(rs.ReceiveLsn.Int64))
+	}
+	if rs.ReplyLsn.Valid {
+		ch <- counter(dWalReplyLsn, float64(rs.ReplyLsn.Int64))
+	}
+	if rs.PrimaryConnectionStatus.Valid {
+		var host, port string
+		for _, f := range strings.Fields(rs.PrimaryConnectionInfo.String) {
+			if strings.HasPrefix(f, "host=") {
+				host = f[len("host="):]
+			}
+			if strings.HasPrefix(f, "port=") {
+				port = f[len("port="):]
+			}
+		}
+		sender := ""
+		if host != "" && port != "" {
+			sender = host + ":" + port
+		}
+		ch <- gauge(dWalReceiverStatus, float64(rs.PrimaryConnectionStatus.Int64), sender)
+	}
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
@@ -292,4 +327,8 @@ func desc(name, help string, labels ...string) *prometheus.Desc {
 
 func gauge(desc *prometheus.Desc, value float64, labels ...string) prometheus.Metric {
 	return prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, value, labels...)
+}
+
+func counter(desc *prometheus.Desc, value float64, labels ...string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(desc, prometheus.CounterValue, value, labels...)
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -34,6 +34,7 @@ var (
 	dLockAwaitingQueries = desc("pg_lock_awaiting_queries", "Number of queries awaiting a lock", "db", "user", "blocking_query")
 
 	dWalReceiverStatus = desc("pg_wal_receiver_status", "WAL receiver status: 1 if the receiver is connected, otherwise 0", "sender_host", "sender_port")
+	dWalReplayPaused   = desc("pg_wal_replay_paused", "Whether WAL replay paused or not")
 	dWalCurrentLsn     = desc("pg_wal_current_lsn", "Current WAL sequence number")
 	dWalReceiveLsn     = desc("pg_wal_receive_lsn", "WAL sequence number that has been received and synced to disk by streaming replication")
 	dWalReplyLsn       = desc("pg_wal_reply_lsn", "WAL sequence number that has been replayed during recovery")
@@ -306,6 +307,13 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			}
 			ch <- gauge(dWalReceiverStatus, float64(rs.PrimaryConnectionStatus.Int64), host, port)
 		}
+		if rs.IsReplayPaused.Valid {
+			value := 0.0
+			if rs.IsReplayPaused.Bool {
+				value = 1.0
+			}
+			ch <- gauge(dWalReplayPaused, value)
+		}
 	}
 }
 
@@ -322,6 +330,7 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- dTopQueryIOTime
 	ch <- dDbQueries
 	ch <- dWalReceiverStatus
+	ch <- dWalReplayPaused
 	ch <- dWalCurrentLsn
 	ch <- dWalReceiveLsn
 	ch <- dWalReplyLsn

--- a/collector/pg_replication.go
+++ b/collector/pg_replication.go
@@ -8,9 +8,10 @@ import (
 )
 
 type replicationStatus struct {
-	CurrentLsn sql.NullInt64
-	ReceiveLsn sql.NullInt64
-	ReplyLsn   sql.NullInt64
+	CurrentLsn     sql.NullInt64
+	ReceiveLsn     sql.NullInt64
+	ReplyLsn       sql.NullInt64
+	IsReplayPaused sql.NullBool
 
 	PrimaryConnectionInfo   sql.NullString
 	PrimaryConnectionStatus sql.NullInt64
@@ -26,23 +27,27 @@ func (c *Collector) getReplicationStatus(version semver.Version) (*replicationSt
 		return nil, fmt.Errorf("pg_is_in_recovery() returned null")
 	}
 
-	var fCurrentLsn, fReceiveLsn, fReplyLsn string
+	var fCurrentLsn, fReceiveLsn, fReplyLsn, fIsReplayPaused string
 	switch {
 	case semver.MustParseRange(">=9.4.0 <10.0.0")(version):
 		fCurrentLsn = "pg_current_xlog_location"
 		fReceiveLsn = "pg_last_xlog_receive_location"
 		fReplyLsn = "pg_last_xlog_replay_location"
+		fIsReplayPaused = "pg_is_xlog_replay_paused"
 	case semver.MustParseRange(">=10.0.0")(version):
 		fCurrentLsn = "pg_current_wal_lsn"
 		fReceiveLsn = "pg_last_wal_receive_lsn"
 		fReplyLsn = "pg_last_wal_replay_lsn"
+		fIsReplayPaused = "pg_is_wal_replay_paused"
 	default:
 		return nil, fmt.Errorf("postgres version %s is not supported", version)
 	}
 
 	var res replicationStatus
 	if isReplica.Bool {
-		if err := c.db.QueryRow(fmt.Sprintf(`SELECT %s()-'0/0', %s()-'0/0'`, fReceiveLsn, fReplyLsn)).Scan(&res.ReceiveLsn, &res.ReplyLsn); err != nil {
+		if err := c.db.QueryRow(fmt.Sprintf(
+			`SELECT %s()-'0/0', %s()-'0/0', %s()`, fReceiveLsn, fReplyLsn, fIsReplayPaused)).Scan(
+			&res.ReceiveLsn, &res.ReplyLsn, &res.IsReplayPaused); err != nil {
 			return nil, err
 		}
 		if err := c.db.QueryRow(`SELECT count(1) FROM pg_stat_wal_receiver`).Scan(&res.PrimaryConnectionStatus); err != nil {

--- a/collector/pg_replication_test.go
+++ b/collector/pg_replication_test.go
@@ -1,0 +1,31 @@
+package collector
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_parsePrimaryConnectionInfo(t *testing.T) {
+	check := func(src string, host, port string) {
+		rs := replicationStatus{primaryConnectionInfo: src}
+		h, p, err := rs.primaryHostPort()
+		assert.NoError(t, err)
+		assert.Equal(t, host, h)
+		assert.Equal(t, port, p)
+	}
+
+	check("host=127.0.0.1 port=5432", "127.0.0.1", "5432")
+	check("host=127.0.0.1", "127.0.0.1", "")
+
+	check("host = 127.0.0.1 port = 5432", "127.0.0.1", "5432")
+	check("host = '127.0.0.1' port = 5432", "127.0.0.1", "5432")
+	check("host = ' 127.0.0.1 ' port = 5432", "127.0.0.1", "5432")
+
+	check("hostaddr=127.0.0.1 port=5432", "127.0.0.1", "5432")
+
+	check("postgresql://localhost:5433", "localhost", "5433")
+	check("postgres://localhost:5433", "localhost", "5433")
+	check("postgresql://user:secret@localhost", "localhost", "")
+	check("postgresql://other@localhost/otherdb?connect_timeout=10&application_name=myapp", "localhost", "")
+	check("postgresql://[2001:db8::1234]/database", "2001:db8::1234", "")
+}


### PR DESCRIPTION
| metric | type | instance role | description |
|-----|-----|-----|-----|
| pg_wal_receiver_status | gauge | replica | WAL receiver status: 1 if the receiver is connected, otherwise 0 |
| pg_wal_current_lsn | counter | primary | Current WAL sequence number |
| pg_wal_receive_lsn | counter | replica | WAL sequence number that has been received and synced to disk by streaming replication |
| pg_wal_reply_lsn | counter | replica | WAL sequence number that has been replayed during recovery |