### PR TITLE
fix getting track_activity_query_size value

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -145,6 +145,8 @@ func (c *Collector) snapshot() {
 				querySizeLimit = int(s.Value)
 			case "kB":
 				querySizeLimit = int(s.Value) * 1024
+			default:
+				querySizeLimit = int(s.Value)
 			}
 			break
 		}


### PR DESCRIPTION
On Postgresql<=11, track_activity_query_size has no unit, so it should be considered as bytes by default

Fixes #17 